### PR TITLE
Fix: Battery Heating Icon incorrectly shown on reload

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
       batterySize: 80,
       maxCarPower: null,
       initialTemperature: 25,
-      batteryHeatingEnabled: true,
+      batteryHeatingEnabled: false,
       endPercentage: 100
     };
     

--- a/models/BatteryPack.ts
+++ b/models/BatteryPack.ts
@@ -29,7 +29,6 @@ export class BatteryPack {
     this._coolingPower = coolingPower;
     this._maxCarPower = maxCarPower;
     this._initialTemperature = initialTemperature;
-    this._batteryHeatingEnabled = false;
     
     const cellsInSeries400 = 108;
     const cellsInSeries800 = 216; 


### PR DESCRIPTION
Fixes #1

This PR ensures the Battery Heating Icon is not displayed after a page reload unless the heating condition is actually active.

Tested:
- Icon does not appear on reload when inactive ✅
- Icon still appears when heating is triggered ✅