### PR TITLE
Fix: Reset button now fully resets battery pack state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,15 +31,15 @@ export default function Home() {
       endPercentage: 100
     };
     
-    const batteryPack = new BatteryPack(
-      defaultConfig.batterySize,
-      defaultConfig.systemVoltage,
-      defaultConfig.maxCRate,
-      defaultConfig.coolingPower,
-      defaultConfig.maxCarPower,
-      defaultConfig.initialTemperature,
-      defaultConfig.batteryHeatingEnabled
-    );
+    const batteryPack = new BatteryPack({
+      batteryCapacityKWh: defaultConfig.batterySize,
+      systemVoltage: defaultConfig.systemVoltage,
+      maxCRate: defaultConfig.maxCRate,
+      coolingPower: defaultConfig.coolingPower,
+      maxCarPower: defaultConfig.maxCarPower,
+      initialTemperature:defaultConfig.initialTemperature,
+      batteryHeatingEnabled: defaultConfig.batteryHeatingEnabled
+    });
     
     const sim = new ChargingSimulation(batteryPack, defaultConfig.chargerType);
     sim.setTimeAcceleration(timeAcceleration);
@@ -75,15 +75,15 @@ export default function Home() {
     }
     
     // Create new battery pack with updated config
-    const batteryPack = new BatteryPack(
-      config.batterySize,
-      config.systemVoltage, 
-      config.maxCRate,
-      config.coolingPower,
-      config.maxCarPower,
-      config.initialTemperature,
-      config.batteryHeatingEnabled
-    );
+    const batteryPack = new BatteryPack({
+      batteryCapacityKWh: config.batterySize,
+      systemVoltage: config.systemVoltage,
+      maxCRate: config.maxCRate,
+      coolingPower: config.coolingPower,
+      maxCarPower: config.maxCarPower,
+      initialTemperature: config.initialTemperature,
+      batteryHeatingEnabled: config.batteryHeatingEnabled,
+    });
     
     // Create new simulation with updated battery pack
     const newSimulation = new ChargingSimulation(batteryPack, config.chargerType);

--- a/models/BatteryPack.ts
+++ b/models/BatteryPack.ts
@@ -1,5 +1,24 @@
 import { Cell } from './Cell';
 
+interface BatteryPackOptions {
+  batteryCapacityKWh?: number;
+  systemVoltage?: number;
+  maxCRate?: number;
+  coolingPower?: number;
+  maxCarPower?: number | null;
+  initialTemperature?: number;
+  batteryHeatingEnabled?: boolean;
+}
+
+const DEFAULT_OPTIONS = {
+  limitingFactor: null,
+  initialTemperature: 25,
+  batteryHeatingEnabled: false,
+  balancingIntensity: 0,
+  avgSoc: 0,
+  cellsBalanced: 0,
+}
+
 export class BatteryPack {
   private _cells: Cell[] = [];
   private _systemVoltage: number;
@@ -7,23 +26,23 @@ export class BatteryPack {
   private _coolingPower: number;
   private _maxCarPower: number | null;
   private _limitingFactor: string | null = null;
-  private _initialTemperature: number = 25;
-  private _batteryHeatingEnabled: boolean = false;
+  private _initialTemperature: number = DEFAULT_OPTIONS.initialTemperature;
+  private _batteryHeatingEnabled: boolean = DEFAULT_OPTIONS.batteryHeatingEnabled;
   private _cellsInSeries: number;
   private _cellsInParallel: number;
-  private _balancingIntensity: number = 0;
-  private _avgSoc: number = 0;
-  private _cellsBalanced: number = 0;
+  private _balancingIntensity: number = DEFAULT_OPTIONS.balancingIntensity;
+  private _avgSoc: number = DEFAULT_OPTIONS.avgSoc;
+  private _cellsBalanced: number = DEFAULT_OPTIONS.cellsBalanced;
 
-  constructor(
-    batteryCapacityKWh: number = 80,
-    systemVoltage: number = 400,
-    maxCRate: number = 2,
-    coolingPower: number = 1,
-    maxCarPower: number | null = null,
-    initialTemperature: number = 25,
-    batteryHeatingEnabled: boolean = false
-  ) {
+  constructor({
+    batteryCapacityKWh = 80,
+    systemVoltage = 400,
+    maxCRate = 2,
+    coolingPower = 1,
+    maxCarPower = null,
+    initialTemperature = DEFAULT_OPTIONS.initialTemperature,
+    batteryHeatingEnabled = DEFAULT_OPTIONS.batteryHeatingEnabled,
+  }: BatteryPackOptions) {
     this._systemVoltage = systemVoltage;
     this._maxCRate = maxCRate;
     this._coolingPower = coolingPower;
@@ -367,8 +386,12 @@ export class BatteryPack {
     // Reset all cells to initial state
     this._cells.forEach(cell => {
       cell.reset(this._initialTemperature);
-      cell.stateOfCharge = 0.0; // Explicitly set SoC to 0
     });
+    
+    this._limitingFactor = DEFAULT_OPTIONS.limitingFactor;
+    this._balancingIntensity = DEFAULT_OPTIONS.balancingIntensity;
+    this._avgSoc = DEFAULT_OPTIONS.avgSoc;
+    this._cellsBalanced = DEFAULT_OPTIONS.cellsBalanced;
     
     // Apply heating setting after reset
     if (this._batteryHeatingEnabled) {

--- a/models/Cell.ts
+++ b/models/Cell.ts
@@ -78,7 +78,7 @@ export class Cell {
 
   updateCharge(current: number, deltaTimeHours: number): void {
     // Apply temperature-based charging limitation
-    let effectiveCurrent = current;
+    const effectiveCurrent = current;
     
     // Each cell has a significantly different charging efficiency
     // This creates more pronounced imbalance over time
@@ -150,8 +150,11 @@ export class Cell {
 
   reset(initialTemperature: number = 25): void {
     this._temperature = initialTemperature;
-    this._stateOfCharge = 0.1;
+    this._ambientTemperature = initialTemperature;
+    this._stateOfCharge = 0.0;
+    this._charge = this._stateOfCharge * this._capacity;
     this._heatingEnabled = false;
+    this._wasBalanced = false;
   }
 
   private updateVoltage(): void {

--- a/models/ChargingSimulation.ts
+++ b/models/ChargingSimulation.ts
@@ -96,16 +96,15 @@ export class ChargingSimulation {
   }
 
   reset(): void {
-    // Reset the battery pack
+    this.stop();
+    this._elapsedTime = 0;
+    this._fullPointSoC = 0;
+    this._lastUpdateTime = 0;
+    
     this._batteryPack.reset();
     
     // Clear all data points
     this._dataPoints = [];
-    
-    // Reset elapsed time
-    this._elapsedTime = 0;
-    
-    // Add initial data point at 0% SoC
     this._dataPoints.push({
       time: 0,
       soc: this._batteryPack.averageSoc,


### PR DESCRIPTION
Fixes #2

This PR ensures that the Reset button correctly resets all relevant internal states of the `BatteryPack` and `ChargingSimulation` objects.

Previously, certain values persisted after reset due to partial reinitialization. This fix restores all default or initial values, ensuring a complete simulation reset.

Additionally, added a `DEFAULT_OPTIONS` object for better manageability and consistency when resetting internal values.
